### PR TITLE
Various Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project is in a very early stage, with limited functionality. Don't use in 
     this.use('mongodb', {
       connection: "mongodb://localhost/databaseName", // required - the mongo URI of the database
       collection: "people", // required - the name of the collection
-      safe : true // optional - run the driver in safe mode to ensure that the update succeeded. Defaults to false
+      safe: true // optional - run the driver in safe mode to ensure that the update succeeded. Defaults to false
     });
     
     this.string('name');
@@ -37,7 +37,7 @@ This project is in a very early stage, with limited functionality. Don't use in 
       host: "localhost", 
       database: "databaseName",
       collection: "flowers",
-      safe : true 
+      safe: true 
     });
     
     this.string('color');
@@ -46,9 +46,9 @@ This project is in a very early stage, with limited functionality. Don't use in 
 
   //Open the mongodb connection
   resourceful.use('mongodb', {
-    conection: "mongodb://localhost/markover", // required - the connection to be opened
-    onConnect: function(err) { // required - the callback upon opening the database connection
-        if (!err) app.start();
+    connection: "mongodb://localhost/markover", // required - the connection to be opened
+    onConnect: function (err) { // required - the callback upon opening the database connection
+        if (!err) app.start(8000);
     }
   });
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This project is in a very early stage, with limited functionality. Don't use in 
 
   //Open the mongodb connection
   resourceful.use('mongodb', {
-    connection: "mongodb://localhost/markover", // required - the connection to be opened
+    connection: "mongodb://localhost/databaseName", // required - the connection to be opened
     onConnect: function (err) { // required - the callback upon opening the database connection
         if (!err) app.start(8000);
     }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project is in a very early stage, with limited functionality. Don't use in 
   var Person = resourceful.define('person', function () {
 
     this.use('mongodb', {
-      connection: "mongodb://localhost/databaseName", // required - the mongo URI of the database
+      uri: "mongodb://localhost/databaseName", // required - the mongo URI of the database
       collection: "people", // required - the name of the collection
       safe: true // optional - run the driver in safe mode to ensure that the update succeeded. Defaults to false
     });
@@ -46,7 +46,7 @@ This project is in a very early stage, with limited functionality. Don't use in 
 
   //Open the mongodb connection
   resourceful.use('mongodb', {
-    connection: "mongodb://localhost/databaseName", // required - the connection to be opened
+    uri: "mongodb://localhost/databaseName", // required - the connection to be opened
     onConnect: function (err) { // required - the callback upon opening the database connection
         if (!err) app.start(8000);
     }

--- a/README.md
+++ b/README.md
@@ -16,18 +16,40 @@ This project is in a very early stage, with limited functionality. Don't use in 
 ``` js
   var resourceful = require('resourceful-mongo');
   
+  //Define the resources
   var Person = resourceful.define('person', function () {
-    //
-    // Specify use of the mongodb engine
-    //
+
     this.use('mongodb', {
-      database: 'flatiron_test', //required - databasename which contains collections
-      collection: "people", // required - the collection to use for this resource
+      connection: "mongodb://localhost/databaseName", // required - the mongo URI of the database
+      collection: "people", // required - the name of the collection
       safe : true // optional - run the driver in safe mode to ensure that the update succeeded. Defaults to false
     });
     
     this.string('name');
     this.number('age');
+  });
+
+  var Flower = resourceful.define('flower', function () {
+
+    this.use('mongodb', {
+
+      //The mongo URI can also be defined piecemeal
+      host: "localhost", 
+      database: "databaseName",
+      collection: "flowers",
+      safe : true 
+    });
+    
+    this.string('color');
+    this.number('petals');
+  });
+
+  //Open the mongodb connection
+  resourceful.use('mongodb', {
+    conection: "mongodb://localhost/markover", // required - the connection to be opened
+    onConnect: function(err) { // required - the callback upon opening the database connection
+        if (!err) app.start();
+    }
   });
 ```
 

--- a/lib/resourceful-mongo.js
+++ b/lib/resourceful-mongo.js
@@ -145,14 +145,19 @@ Mongo.prototype.update = function (id, doc, callback) {
 };
 
 Mongo.prototype.get = function(id, callback) {
+
   if(id && typeof id === 'string') {
-    id = new this.database.bson_serializer.ObjectID(id);
+    id = {'_id': new this.database.bson_serializer.ObjectID(id)};
   }
 
-  this.collection(function(err, collection){
+  this.collection(function(err, collection) {
     if(err) return callback(err);
 
-    collection.findOne({"_id": id}, callback);
+    collection.findOne(id, function(err, doc) {
+      if (err) return callback(err);
+
+      callback(null, doc || {});
+    });
   });
 };
 

--- a/lib/resourceful-mongo.js
+++ b/lib/resourceful-mongo.js
@@ -8,9 +8,7 @@ exports.connection = {};
 exports.deferred = {};
 
 var Mongo = exports.Mongo = function Mongo(config) {
-  if(!config.collection) {
-    throw new Error('collection must be set in the config for each model.');
-  }
+  var self = this;
 
   if (config.uri) {
     var uri = url.parse('mongodb://' + config.uri, true);
@@ -29,7 +27,7 @@ var Mongo = exports.Mongo = function Mongo(config) {
   config.host     = config.host     || '127.0.0.1';
   config.port     = config.port     || 27017;
   config.database = config.database || resourceful.env || 'test';
-  config.safe     = config.safe     || false;
+  config.safe      = (String(config.safe) === 'true'); 
 
   config.uri = url.format({
     protocol: 'mongodb',

--- a/lib/resourceful-mongo.js
+++ b/lib/resourceful-mongo.js
@@ -86,19 +86,19 @@ var Mongo = exports.Mongo = function Mongo(config) {
 
 Mongo.prototype.protocol = 'mongodb';
 
+//Lazy-load the resource's collection
 Mongo.prototype.collection = function(callback) {
   var self = this;
 
-  this.database.open(function(err, client) {
-    if(err) return callback(err);
-
-    client.collection(self.config.collection, function(err, collection) {
+  if (this._collection) {
+    return callback(null, this._collection);
+  } else {
+    this.connection.collection(self.config.collection, function(err, collection) {
       if(err) return callback(err);
-
+      self._collection = collection;
       return callback(null, collection);
     });
-
-  });
+  }
 };
 
 Mongo.prototype.save = function (id, doc, callback) {

--- a/lib/resourceful-mongo.js
+++ b/lib/resourceful-mongo.js
@@ -4,32 +4,84 @@ var url = require('url'),
     Connection = require('mongodb').Connection,
     Server = require('mongodb').Server;
 
+exports.connection = {};
+exports.deferred = {};
+
 var Mongo = exports.Mongo = function Mongo(config) {
   if(!config.collection) {
     throw new Error('collection must be set in the config for each model.');
   }
 
   if (config.uri) {
-    var parsed = url.parse('mongodb://' + config.uri, true);
-    
-    config.host = parsed.hostname;
-    config.port = parseInt(parsed.port, 10);
-    config.database = (parsed.pathname || '').replace(/^\//, '');
+    var uri = url.parse('mongodb://' + config.uri, true);
+    config.host = uri.hostname;
+    config.port = uri.port;
 
-    if(parsed.query) {
-      resourceful.mixin(config, parsed.query);
+    if (uri.pathname) {
+      config.database = uri.pathname.replace(/^\/|\/$/g, '');
+    }
+
+    if (uri.query) {
+      resourceful.mixin(config, uri.query);
     }
   }
 
-  config.host      = config.host || '127.0.0.1';
-  config.port      = config.port || 27017;
-  config.port      = parseInt(config.port, 10);
-  config.safe      = (String(config.safe) === 'true');
-  config.database  = config.database || resourceful.env;
+  config.host     = config.host     || '127.0.0.1';
+  config.port     = config.port     || 27017;
+  config.database = config.database || resourceful.env || 'test';
+  config.safe     = config.safe     || false;
+
+  config.uri = url.format({
+    protocol: 'mongodb',
+    hostname: config.host,
+    port: config.port,
+    pathname: '/'+config.database
+  });
+
+  config.port = parseInt(config.port, 10);
 
   this.config = config;
-  this.database = new Db(this.config.database, new Server(this.config.host, this.config.port, {}));
   this.cache = new resourceful.Cache();
+
+  //If a connection for this URI has already been made, use it
+  if (exports.connection[config.uri]) {
+    this.connection = exports.connection[config.uri];
+
+  //Otherwise if an onConnect callback was given, open a new connection
+  } else if (typeof config.onConnect === 'function') {
+    new Db(config.database, new Server(config.host, config.port, {})).open(function(err, db) {
+      if (err) {
+        return config.onConnect(err);
+      }
+
+      self.connection = exports.connection[config.uri] = db;
+
+      (function handleDeferredAction(i) {
+        if (exports.deferred[config.uri] && i<exports.deferred[config.uri].length) {
+          exports.deferred[config.uri][i](config.uri, function() {
+              handleDeferredAction(++i);
+          });
+        } else {
+          delete exports.deferred[config.uri];
+          config.onConnect();
+        }
+      })(0);
+    });
+
+  //Failing that, just remember to set `this.connection` when the appropriate connection does get made
+  //This makes it easy to define resources before opening their database connection
+  } else {
+    var self = this;
+
+    if (!exports.deferred[config.uri]) {
+      exports.deferred[config.uri] = [];
+    }
+
+    exports.deferred[config.uri].push(function(uri, callback) {
+      self.connection = exports.connection[uri];
+      callback();
+    });
+  }
 };
 
 Mongo.prototype.protocol = 'mongodb';

--- a/lib/resourceful-mongo.js
+++ b/lib/resourceful-mongo.js
@@ -8,10 +8,8 @@ exports.deferred = {};
 var Mongo = exports.Mongo = function Mongo(config) {
   var self = this;
 
-  //
   // This function is being called to specify a database connection, define a model, or both. If
-  // neither a collection name nor an onConnect callback is given, throw an error.
-  // 
+  // neither a collection name nor an onConnect callback is given, throw an error. 
   if ((!config.collection || typeof config.collection !== 'string') && typeof config.onConnect !== 'function') {
       throw new Error("A collection string or onConnect callback must be specified in the config parameter.");
   }
@@ -47,14 +45,11 @@ var Mongo = exports.Mongo = function Mongo(config) {
   this.config = config;
   this.cache = new resourceful.Cache();
 
-  //
   // If a connection for this URI has already been made, use it.
-  //
   if (exports.connections[config.uri]) {
     this.connection = exports.connections[config.uri];
-  //
+
   // Otherwise if an onConnect callback was given, open a new connection.
-  //
   } else if (typeof config.onConnect === 'function') {
     new mongo.Db(config.database, new mongo.Server(config.host, config.port, {})).open(function(err, db) {
       if (err) {
@@ -75,12 +70,11 @@ var Mongo = exports.Mongo = function Mongo(config) {
       })(0);
     });
 
-  //
   // Failing that, just remember to set `this.connection` when the appropriate connection does get made.
   // This makes it easy to define resources before opening their database connection.
-  //
   } else {
     var self = this;
+
     if (!exports.deferred[config.uri]) {
       exports.deferred[config.uri] = [];
     }
@@ -94,9 +88,7 @@ var Mongo = exports.Mongo = function Mongo(config) {
 
 Mongo.prototype.protocol = 'mongodb';
 
-//
 // Lazy-load the resource's collection
-//
 Mongo.prototype.collection = function(callback) {
   var self = this;
 
@@ -121,7 +113,7 @@ Mongo.prototype.save = function (id, doc, callback) {
   }
 
   if(doc._id && typeof doc._id === 'string') {
-     doc._id = mongo.ObjectID.createFromHexString(doc._id);
+     doc._id = mongo.ObjectID(doc._id);
   }
 
   var config = this.config;
@@ -143,35 +135,35 @@ Mongo.prototype.save = function (id, doc, callback) {
 
 Mongo.prototype.update = function (id, doc, callback) {
   var self = this;
-  
-  // if(id && typeof id === 'string') {
-  //   id = new this.database.bson_serializer.ObjectID(id);
-  // }
+
+  if(id && typeof id === 'string') {
+    id = {'_id': mongo.ObjectID(id)};
+  }
+
   var config = this.config;
 
   this.collection(function(err, collection){
     if(err) return callback(err);
 
-    collection.update({"_id" : id}, {$set: doc}, {safe : config.safe}, function(err) {
+    collection.update(id, {$set: doc}, {safe : config.safe}, function(err) {
       if(err) return callback(err);
-      
+
       return self.get(id, callback);
     });
-
   });
 };
 
 Mongo.prototype.get = function(id, callback) {
 
   if(id && typeof id === 'string') {
-    id = {'_id': new this.database.bson_serializer.ObjectID(id)};
+    id = {'_id': mongo.ObjectID(id)};
   }
 
   this.collection(function(err, collection) {
     if(err) return callback(err);
 
     collection.findOne(id, function(err, doc) {
-      if (err) return callback(err);
+      if(err) return callback(err);
 
       callback(null, doc || {});
     });
@@ -179,20 +171,25 @@ Mongo.prototype.get = function(id, callback) {
 };
 
 Mongo.prototype.find = function(criteria, callback) {
-  this.collection(function(err, collection){
+  this.collection(function(err, collection) {
     collection.find(criteria).toArray(callback);
   });
 };
 
 Mongo.prototype.destroy = function(id, callback) {
+
+  if(id && typeof id === 'string') {
+    id = {'_id': mongo.ObjectID(id)};
+  }
+
   var config = this.config;
   
   this.collection(function(err, collection) {
-    collection.remove({"_id": id}, {safe : config.safe}, callback);
+    collection.remove(id, {safe : config.safe}, callback);
   });
 };
 
-// register engine with resourceful
+//register engine with resourceful
 resourceful.engines.Mongodb = Mongo;
 
 //export resourceful

--- a/lib/resourceful-mongo.js
+++ b/lib/resourceful-mongo.js
@@ -1,8 +1,6 @@
 var url = require('url'),
     resourceful = require('resourceful'),
-    Db = require('mongodb').Db,
-    Connection = require('mongodb').Connection,
-    Server = require('mongodb').Server;
+    mongo = require('mongodb');
 
 exports.connections = {};
 exports.deferred = {};
@@ -58,7 +56,7 @@ var Mongo = exports.Mongo = function Mongo(config) {
   // Otherwise if an onConnect callback was given, open a new connection.
   //
   } else if (typeof config.onConnect === 'function') {
-    new Db(config.database, new Server(config.host, config.port, {})).open(function(err, db) {
+    new mongo.Db(config.database, new mongo.Server(config.host, config.port, {})).open(function(err, db) {
       if (err) {
         return config.onConnect(err);
       }
@@ -122,21 +120,25 @@ Mongo.prototype.save = function (id, doc, callback) {
     doc._id = id;
   }
 
-  // if(doc._id && typeof doc._id === 'string') {
-  //   doc._id = new this.database.bson_serializer.ObjectID(doc._id);
-  // }
+  if(doc._id && typeof doc._id === 'string') {
+     doc._id = mongo.ObjectID.createFromHexString(doc._id);
+  }
 
   var config = this.config;
 
   this.collection(function(err, collection) {
     if(err) return callback(err);
 
-    collection.save(doc, {safe : config.safe}, function(err, documents) {
+    collection.save(doc, {safe : config.safe}, function(err, doc) {
       if (err) return callback(err);
-      callback(null, documents);
+
+      if (doc._id) {
+        doc._id = doc._id.toString();
+      } 
+
+      callback(null, doc);
     });
   });
-
 };
 
 Mongo.prototype.update = function (id, doc, callback) {

--- a/lib/resourceful-mongo.js
+++ b/lib/resourceful-mongo.js
@@ -4,11 +4,19 @@ var url = require('url'),
     Connection = require('mongodb').Connection,
     Server = require('mongodb').Server;
 
-exports.connection = {};
+exports.connections = {};
 exports.deferred = {};
 
 var Mongo = exports.Mongo = function Mongo(config) {
   var self = this;
+
+  //
+  // This function is being called to specify a database connection, define a model, or both. If
+  // neither a collection name nor an onConnect callback is given, throw an error.
+  // 
+  if ((!config.collection || typeof config.collection !== 'string') && typeof config.onConnect !== 'function') {
+      throw new Error("A collection string or onConnect callback must be specified in the config parameter.");
+  }
 
   if (config.uri) {
     var uri = url.parse('mongodb://' + config.uri, true);
@@ -27,7 +35,7 @@ var Mongo = exports.Mongo = function Mongo(config) {
   config.host     = config.host     || '127.0.0.1';
   config.port     = config.port     || 27017;
   config.database = config.database || resourceful.env || 'test';
-  config.safe      = (String(config.safe) === 'true'); 
+  config.safe     = (String(config.safe) === 'true'); 
 
   config.uri = url.format({
     protocol: 'mongodb',
@@ -41,18 +49,21 @@ var Mongo = exports.Mongo = function Mongo(config) {
   this.config = config;
   this.cache = new resourceful.Cache();
 
-  //If a connection for this URI has already been made, use it
-  if (exports.connection[config.uri]) {
-    this.connection = exports.connection[config.uri];
-
-  //Otherwise if an onConnect callback was given, open a new connection
+  //
+  // If a connection for this URI has already been made, use it.
+  //
+  if (exports.connections[config.uri]) {
+    this.connection = exports.connections[config.uri];
+  //
+  // Otherwise if an onConnect callback was given, open a new connection.
+  //
   } else if (typeof config.onConnect === 'function') {
     new Db(config.database, new Server(config.host, config.port, {})).open(function(err, db) {
       if (err) {
         return config.onConnect(err);
       }
 
-      self.connection = exports.connection[config.uri] = db;
+      self.connection = exports.connections[config.uri] = db;
 
       (function handleDeferredAction(i) {
         if (exports.deferred[config.uri] && i<exports.deferred[config.uri].length) {
@@ -66,17 +77,18 @@ var Mongo = exports.Mongo = function Mongo(config) {
       })(0);
     });
 
-  //Failing that, just remember to set `this.connection` when the appropriate connection does get made
-  //This makes it easy to define resources before opening their database connection
+  //
+  // Failing that, just remember to set `this.connection` when the appropriate connection does get made.
+  // This makes it easy to define resources before opening their database connection.
+  //
   } else {
     var self = this;
-
     if (!exports.deferred[config.uri]) {
       exports.deferred[config.uri] = [];
     }
 
     exports.deferred[config.uri].push(function(uri, callback) {
-      self.connection = exports.connection[uri];
+      self.connection = exports.connections[uri];
       callback();
     });
   }
@@ -84,7 +96,9 @@ var Mongo = exports.Mongo = function Mongo(config) {
 
 Mongo.prototype.protocol = 'mongodb';
 
-//Lazy-load the resource's collection
+//
+// Lazy-load the resource's collection
+//
 Mongo.prototype.collection = function(callback) {
   var self = this;
 
@@ -117,7 +131,10 @@ Mongo.prototype.save = function (id, doc, callback) {
   this.collection(function(err, collection) {
     if(err) return callback(err);
 
-    collection.save(doc, {safe : config.safe}, callback);
+    collection.save(doc, {safe : config.safe}, function(err, documents) {
+      if (err) return callback(err);
+      callback(null, documents);
+    });
   });
 
 };

--- a/test/resourceful-mongo-test.js
+++ b/test/resourceful-mongo-test.js
@@ -74,11 +74,22 @@ describe("Creating", function() {
   });
 });
 
+describe("Saving", function() {
+
+  it("saves without error", function(done) {
+    
+    db.Person.create({ name: 'Bob', age: 99 }, function (err, person) {
+      if (err) done(err);
+      done();
+    });
+  });
+});
+
 describe("Updating", function() {
 
   it("paritally updates model", function(done) {
     db.Person.create({ name: 'Bob', age: 99 }, function (err, person) {
-      if (err) { done(err); }
+      if (err) done(err);
       
       person.update({name:"Steve"}, function(err, person){
         if(err) return done(err);
@@ -141,13 +152,13 @@ describe("Finding", function(){
 
 describe("Destroying", function() {
   beforeEach(function(done) {
-    db.createPeople([{"_id": "34", name :"bob", age: 22}, db.people.steve], function(err) {
+    db.createPeople([{name: "bob", age: 22}, db.people.steve], function(err) {
       done();
     });
   });
   
   it("by id", function(done) {
-    db.Person.destroy("34", function(err, result) {
+    db.Person.destroy({name: "bob"}, function(err, result) {
       if(err) done(err);
 
       result.should.equal(1);

--- a/test/resourceful-mongo-test.js
+++ b/test/resourceful-mongo-test.js
@@ -3,11 +3,19 @@ var db = require('./test-helper'),
     should = require('should'),
     resourceful = require('resourceful');
 
+beforeEach(db.drop);
+
 describe('Connecting', function() {
 
+  it("open new connection", function(done) {
+    resourceful.use("mongodb", {uri: "mongodb://127.0.0.1:27017/resourceful-mongo-test", onConnect: function(err) {
+       if (err) throw err;
+       done();
+    }});
+  });
+
   it("by uri", function() {
-    var config = resourceful.use("mongodb", {uri:"mongodb://test.mongodb.com:4444/resourceful-mongo-test", collection: "test"}).connection.config;
-    
+    var config = resourceful.use("mongodb", {uri: "mongodb://test.mongodb.com:4444/resourceful-mongo-test", collection: "test"}).connection.config;
     config.host.should.equal("test.mongodb.com");
     config.port.should.equal(4444);
     config.database.should.equal("resourceful-mongo-test");
@@ -52,9 +60,8 @@ describe('Connecting', function() {
 });
 
 describe("Creating", function() {
-  before(db.start);
 
-  it("creates a simple model", function(done){
+  it("creates a simple model", function(done) {
     
     db.Person.create({ name: 'Bob', age: 99 }, function (err, person) {
       if (err) { done(err); }
@@ -65,11 +72,9 @@ describe("Creating", function() {
       done();
     });
   });
-
 });
 
 describe("Updating", function() {
-  before(db.start);
 
   it("paritally updates model", function(done) {
     db.Person.create({ name: 'Bob', age: 99 }, function (err, person) {
@@ -83,13 +88,11 @@ describe("Updating", function() {
         done();
       });
     });
-
   });
 
 });
 
 describe("Finding", function(){
-  beforeEach(db.start);
 
   it("all resources", function(done) {
     var p = db.people;
@@ -102,7 +105,6 @@ describe("Finding", function(){
         done();
       });
     });
-
   });
 
   it("by id", function(done) {
@@ -139,10 +141,8 @@ describe("Finding", function(){
 
 describe("Destroying", function() {
   beforeEach(function(done) {
-    db.start(function() {
-      db.createPeople([{"_id": "34", name :"bob"}, db.people.steve], function(err) {
-        done();
-      });
+    db.createPeople([{"_id": "34", name :"bob", age: 22}, db.people.steve], function(err) {
+      done();
     });
   });
   
@@ -154,5 +154,4 @@ describe("Destroying", function() {
       done();
     });
   });
-
 });

--- a/test/resourceful-mongo-test.js
+++ b/test/resourceful-mongo-test.js
@@ -100,7 +100,6 @@ describe("Updating", function() {
       });
     });
   });
-
 });
 
 describe("Finding", function(){
@@ -130,7 +129,6 @@ describe("Finding", function(){
 
         done();
       });
-
     });
   });
 
@@ -145,9 +143,7 @@ describe("Finding", function(){
         done();
       });
     });
-
   });
-
 });
 
 describe("Destroying", function() {
@@ -156,8 +152,21 @@ describe("Destroying", function() {
       done();
     });
   });
-  
+
   it("by id", function(done) {
+
+    db.Person.create(db.people.bob, function(err, bob) {
+      db.Person.destroy(bob.id, function(err, result) {
+
+        if(err) done(err);
+  
+        result.should.equal(1);
+        done();
+      });
+    });
+  });
+  
+  it("by name", function(done) {
     db.Person.destroy({name: "bob"}, function(err, result) {
       if(err) done(err);
 

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -19,6 +19,8 @@ DB.start = function(callback) {
   // drop the test database
   var testDB = new mongodb(testConnection.database, new Server(testConnection.host, testConnection.port, {}));
   testDB.open(function(err, db) {
+    if (err) throw err
+
     db.dropDatabase(callback);
   });
 

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -37,7 +37,7 @@ DB.createPerson = function(person, callback) {
 
 DB.drop = function(callback) {
 
-  this.timeout(10000);
+  this.timeout(10000); //The tests are a bit slow because the database is dropped before each one.
 
   if (!DB.Person.connection.connection) return callback();
 


### PR DESCRIPTION
Hi codebrew team,

Here are a couple of changes I've made in an effort to bring resourceful-mongo a bit closer to a production-ready state. Sorry to stuff all of this into a single pull request. 
### Implementation changes
- A single mongo connection is opened per database. It is re-used from operation to operation
- A single mongo collection object is created per resource and then reused for each operation
### Interface changes
- If an object is passed to get() instead of an ID string, it will treat the object as the condition to a findOne query
- Likewise, updating and removing can be performed by using a query object, in addition to just using an ID
- Defining resources and opening a database connection are two separate steps (see README changes)
